### PR TITLE
Remove output.css reference

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -3,9 +3,7 @@ import { Head, Html, Main, NextScript } from 'next/document'
 const Document = () => {
   return (
     <Html lang='en'>
-      <Head>
-        <link href={'/dist/output.css'} />
-      </Head>
+      <Head />
       <body>
         <Main />
         <NextScript />


### PR DESCRIPTION
- This output file is only needed for html files, and not needed for Next.js