### PR TITLE
Replace tailwind drop-shadow with css due to webkit compatibility issues

### DIFF
--- a/src/components/mainCalendar/Month.tsx
+++ b/src/components/mainCalendar/Month.tsx
@@ -101,7 +101,7 @@ export const Month = (props: MonthProps) => {
       const hiddenElemCount = allDayBlocks.length - nonOverflowElemCount + 1
       return (
         <Popover className={'mx-1 mt-1'} key={day.format('YY-MM-DD')}>
-          <Popover.Button className={'border-box flex w-full rounded-md px-1 hover:bg-slate-100'}>
+          <Popover.Button className={'border-box flex w-full rounded-md px-1 hover:bg-slate-100 focus:outline-none'}>
             {hiddenElemCount + ' more'}
           </Popover.Button>
           <Transition
@@ -114,7 +114,14 @@ export const Month = (props: MonthProps) => {
             leaveTo={`opacity-0 ${appearBelow ? 'translate-y-1' : ''}`}
           >
             <Popover.Panel className={`${translateXClass} ${translateYClass} z-100 absolute transform`}>
-              <div className='h-fit max-h-60 w-60 overflow-y-auto rounded-lg rounded-md bg-white drop-shadow-[0_0_15px_rgba(0,0,0,0.25)]'>
+              <style jsx>{`
+                div {
+                  box-shadow: 0 0 15px rgba(0, 0, 0, 0.25);
+                  -webkit-box-shadow: 0 0 15px rgba(0, 0, 0, 0.25);
+                  -moz-box-shadow: 0 0 15px rgba(0, 0, 0, 0.25);
+                }
+              `}</style>
+              <div className='h-fit max-h-60 w-60 overflow-y-auto rounded-lg rounded-md bg-white'>
                 {getPopoverContent(day, offsetFromMonthStart, allDayBlocks)}
               </div>
             </Popover.Panel>


### PR DESCRIPTION
Safari:
<img width="354" alt="Screenshot 2023-03-15 at 5 49 14 PM" src="https://user-images.githubusercontent.com/39626451/225480739-a87e52ca-19a0-48ff-a361-dc2a83e684cc.png">

Chrome:
<img width="354" alt="Screenshot 2023-03-15 at 5 49 29 PM" src="https://user-images.githubusercontent.com/39626451/225480823-9fbe0e58-1af7-4fc4-a582-18f34e421f69.png">