### PR TITLE
Only load required data on initial page load

### DIFF
--- a/__tests__/api/cats/index.test.ts
+++ b/__tests__/api/cats/index.test.ts
@@ -46,6 +46,21 @@ describe('/api/cats', () => {
       expect(res._getStatusCode()).toBe(200)
       expect(res._getData()).toBe(JSON.stringify(mock_cats))
     })
+
+    it('should return a 400 status code when year is invalid', async () => {
+      const req = createRequest({
+        method: 'GET',
+        url: '/cats?year=abc',
+        query: {
+          year: 'abc'
+        }
+      })
+      const res = createResponse()
+      await cats(req, res)
+
+      expect(res._getStatusCode()).toBe(400)
+      expect(res._getData()).toBe('Bad Request')
+    })
   })
 
   describe('POST', () => {

--- a/src/lib/prisma/queries.ts
+++ b/src/lib/prisma/queries.ts
@@ -1,6 +1,6 @@
 import prisma from '@/prisma/prismadb'
 
-const select = {
+const selectAll = {
   id: true,
   name: true,
   description: true,
@@ -14,8 +14,8 @@ const select = {
   icon: true
 }
 
-// returns all master categories and personal categories for a user
-export const getCategories = async (creatorId?: string) => {
+// returns all master categories and personal categories for a user without the entries included
+export const getCategoriesWithoutEntries = async (creatorId?: string) => {
   return prisma.category.findMany({
     where: {
       OR: [
@@ -27,7 +27,45 @@ export const getCategories = async (creatorId?: string) => {
         }
       ]
     },
-    select
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      color: true,
+      isMaster: true,
+      cron: true,
+      startDate: true,
+      endDate: true,
+      creator: true,
+      icon: true
+    }
+  })
+}
+
+// returns all master categories and personal categories for a user for a given year (if provided)
+export const getCategories = async (creatorId?: string, year?: number) => {
+  return prisma.category.findMany({
+    where: {
+      OR: [
+        {
+          creatorId: creatorId
+        },
+        {
+          isMaster: true
+        }
+      ],
+      entries: year
+        ? {
+            some: {
+              date: {
+                gte: new Date(year, 0, 1),
+                lte: new Date(year, 11, 31)
+              }
+            }
+          }
+        : undefined
+    },
+    select: selectAll
   })
 }
 
@@ -37,7 +75,7 @@ export const getMasterCategories = async () => {
     where: {
       isMaster: true
     },
-    select
+    select: selectAll
   })
 }
 
@@ -48,7 +86,7 @@ export const getPersonalCategories = async (creatorId: string) => {
       creatorId: creatorId,
       isMaster: false
     },
-    select
+    select: selectAll
   })
 }
 
@@ -60,6 +98,6 @@ export const getCategoriesById = async (categoryIds: number[]) => {
         in: categoryIds
       }
     },
-    select
+    select: selectAll
   })
 }

--- a/src/pages/api/cats/index.ts
+++ b/src/pages/api/cats/index.ts
@@ -4,11 +4,24 @@ import dayjs from 'dayjs'
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { Entry } from '@prisma/client'
 import { getToken } from 'next-auth/jwt'
+import z from 'zod'
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   switch (req.method) {
     case 'GET':
-      const categories = await getCategories()
+      const schema = z.object({
+        userID: z.string().optional(),
+        year: z.number().optional()
+      })
+      let id, year
+      try {
+        const parsed = schema.parse(req.query)
+        id = parsed.userID
+        year = parsed.year
+      } catch (e) {
+        return res.status(400).send('Bad Request')
+      }
+      const categories = await getCategories(id, year)
       return res.status(200).json(categories)
     case 'PUT': {
       const token = await getToken({ req })


### PR DESCRIPTION
The new logic for rendering the page is:
- in SSR only load entries for categories with some entry in the current year, where current year is set in the URL else use current year
- on initial page render, make a fetch request to get all AppData
- update the App state with the new data

This does not necessarily remove #100 if you have categories with 600+ entries total in the current year as we do. But it ensures that we are loading the minimum amount of data to provide a seamless user experience. 

This new logic does have one issue. If the end-user switches the year immediately after the page load, faster than the fetch, then they may see some data missing for less than 0.5 seconds (depending on their internet speed).

One solution is to load data for three years: prev, current and next year.

closes #100 