### PR TITLE
Watch year so it recalculates items per box

### DIFF
--- a/src/components/mainCalendar/Month.tsx
+++ b/src/components/mainCalendar/Month.tsx
@@ -175,7 +175,10 @@ export const Month = (props: MonthProps) => {
           )
         } else {
           return (
-            <span className={`${isMonthView ? 'h-8 w-8' : 'h-6 w-6'} px-0.5 font-bold`} key={`${key}-${entry.id}`}>
+            <span
+              className={`${isMonthView ? 'h-8 w-8' : 'h-6 w-6'} px-0.5 text-center font-bold`}
+              key={`${key}-${entry.id}`}
+            >
               <style jsx>{`
                 * {
                   color: ${category.color};


### PR DESCRIPTION
- Had an issue where 6-week months still used the 5-week months' icon count when in year scroll view.
- fix eslint issues with Month.tsx

### Checklist

(i think it's ok)
- [ ] Unit tests pass locally with my changes
- [ ] Updated Unit tests (if necessary)
- [ ] E2E tests pass locally with my changes
- [ ] Updated E2E tests (if necessary)
